### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-b1d82921-8b15-4d39-b230-092686f6dbd6 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-b1d82921-8b15-4d39-b230-092686f6dbd6-750a583c-bc71-43d5-af25-df0dba4bcaf0.yaml
+++ b/workloads/volume-resize-pvc-b1d82921-8b15-4d39-b230-092686f6dbd6-750a583c-bc71-43d5-af25-df0dba4bcaf0.yaml
@@ -1,0 +1,49 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-b1d82921-8b15-4d39-b230-092686f6dbd6
+    rule: volume-resize
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    manager: autopilot
+    operation: Update
+    time: "2021-06-14T22:16:53Z"
+  name: volume-resize-pvc-b1d82921-8b15-4d39-b230-092686f6dbd6
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-564dfb97
+        uid: fbd8f221-853d-43c4-b179-134d9960369c
+      uid: pvc-b1d82921-8b15-4d39-b230-092686f6dbd6
+  lastProcessTimestamp: "2021-06-14T22:16:53Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 10Gi to 20Gi
 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-b1d82921-8b15-4d39-b230-092686f6dbd6)
  - Object Owner(s):
    - ReplicaSet pgbench-564dfb97      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
