### PR TITLE
[Autopilot] approval for rule gitops/volume-resize-gitops-pvc-420a6f0f-f885-42e4-946d-1babefb24f85 rule: volume-resize-gitops

### DIFF
--- a/workloads/volume-resize-gitops-pvc-420a6f0f-f885-42e4-946d-1babefb24f85-9122a622-641c-4f89-8c75-c5a5773e14fe.yaml
+++ b/workloads/volume-resize-gitops-pvc-420a6f0f-f885-42e4-946d-1babefb24f85-9122a622-641c-4f89-8c75-c5a5773e14fe.yaml
@@ -1,0 +1,49 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-420a6f0f-f885-42e4-946d-1babefb24f85
+    rule: volume-resize-gitops
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    manager: autopilot
+    operation: Update
+    time: "2021-06-15T15:37:24Z"
+  name: volume-resize-gitops-pvc-420a6f0f-f885-42e4-946d-1babefb24f85
+  namespace: gitops
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 100Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize-gitops
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 100Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 30Gi to 60Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: gitops
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-749ff8c7d8
+        uid: f32c212a-7fba-4f39-a3c9-3487fcb33634
+      uid: pvc-420a6f0f-f885-42e4-946d-1babefb24f85
+  lastProcessTimestamp: "2021-06-15T15:37:24Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize-gitops__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:100Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 30Gi to 60Gi
 
#### What objects will get affected

- PersistentVolumeClaim gitops/pgbench-data (pvc-420a6f0f-f885-42e4-946d-1babefb24f85)
  - Object Owner(s):
    - ReplicaSet pgbench-749ff8c7d8      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
