### PR TITLE
[Autopilot] approval for rule auto/volume-resize-pvc-5f851043-98ee-4ba1-a521-2174c1632d8d rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-5f851043-98ee-4ba1-a521-2174c1632d8d-831d277e-67fd-48df-875a-6f128ce08f3a.yaml
+++ b/workloads/volume-resize-pvc-5f851043-98ee-4ba1-a521-2174c1632d8d-831d277e-67fd-48df-875a-6f128ce08f3a.yaml
@@ -1,0 +1,49 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-5f851043-98ee-4ba1-a521-2174c1632d8d
+    rule: volume-resize
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    manager: autopilot
+    operation: Update
+    time: "2021-06-15T17:11:38Z"
+  name: volume-resize-pvc-5f851043-98ee-4ba1-a521-2174c1632d8d
+  namespace: auto
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 100Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 100Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 60Gi to 100Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: auto
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-6bc57495fd
+        uid: 42b2c2fa-a760-4f47-9fd0-1893c8e34cf2
+      uid: pvc-5f851043-98ee-4ba1-a521-2174c1632d8d
+  lastProcessTimestamp: "2021-06-15T17:11:38Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:100Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 60Gi to 100Gi
 
#### What objects will get affected

- PersistentVolumeClaim auto/pgbench-data (pvc-5f851043-98ee-4ba1-a521-2174c1632d8d)
  - Object Owner(s):
    - ReplicaSet pgbench-6bc57495fd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
