### PR TITLE
[Autopilot] approval for rule auto/volume-resize-gitops-pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1 rule: volume-resize-gitops

### DIFF
--- a/workloads/volume-resize-gitops-pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1-196b8793-54fc-4426-a10a-769cfc16ab50.yaml
+++ b/workloads/volume-resize-gitops-pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1-196b8793-54fc-4426-a10a-769cfc16ab50.yaml
@@ -1,0 +1,49 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1
+    rule: volume-resize-gitops
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    manager: autopilot
+    operation: Update
+    time: "2021-06-15T18:39:58Z"
+  name: volume-resize-gitops-pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1
+  namespace: auto
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 100Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize-gitops
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 100Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 60Gi to 100Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: auto
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-6bc57495fd
+        uid: 804d9d70-9ca7-493a-b37a-64a4889ae3aa
+      uid: pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1
+  lastProcessTimestamp: "2021-06-15T18:39:58Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize-gitops__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:100Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 60Gi to 100Gi
 
#### What objects will get affected

- PersistentVolumeClaim auto/pgbench-data (pvc-980b0e10-2bf0-4f04-ab1c-f539a30215a1)
  - Object Owner(s):
    - ReplicaSet pgbench-6bc57495fd      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
