### PR TITLE
[Autopilot] approval for rule pg1/volume-resize-pvc-76197b64-d738-43de-908b-2cc4d18dd638 rule: volume-resize

### DIFF
--- a/workloads/volume-resize-pvc-76197b64-d738-43de-908b-2cc4d18dd638-917ec6a6-0843-4bcb-971d-6c5cf242cb2e.yaml
+++ b/workloads/volume-resize-pvc-76197b64-d738-43de-908b-2cc4d18dd638-917ec6a6-0843-4bcb-971d-6c5cf242cb2e.yaml
@@ -1,0 +1,49 @@
+apiVersion: autopilot.libopenstorage.org/v1alpha1
+kind: ActionApproval
+metadata:
+  creationTimestamp: null
+  finalizers:
+  - autopilot.libopenstorage.org/delete
+  labels:
+    object: pvc-76197b64-d738-43de-908b-2cc4d18dd638
+    rule: volume-resize
+  managedFields:
+  - apiVersion: autopilot.libopenstorage.org/v1alpha1
+    manager: autopilot
+    operation: Update
+    time: "2021-07-01T20:28:01Z"
+  name: volume-resize-pvc-76197b64-d738-43de-908b-2cc4d18dd638
+  namespace: pg1
+spec:
+  actions:
+  - name: resize
+    params:
+      maxsize: 400Gi
+      scalepercentage: "100"
+  approvalState: approved
+status:
+  Rule:
+    Name: volume-resize
+    Namespace: ""
+  actionPreviews:
+  - action:
+      name: resize
+      params:
+        maxsize: 400Gi
+        scalepercentage: "100"
+    expectedResult:
+      Message: PVC will resize from 10Gi to 20Gi
+    involvedObjects:
+    - apiVersion: v1
+      kind: PersistentVolumeClaim
+      name: pgbench-data
+      namespace: pg1
+      ownerReferences:
+      - apiVersion: apps/v1
+        blockOwnerDeletion: true
+        controller: true
+        kind: ReplicaSet
+        name: pgbench-564dfb97
+        uid: 4f8348fe-25a3-49a8-acd2-d209a5ad135a
+      uid: pvc-76197b64-d738-43de-908b-2cc4d18dd638
+  lastProcessTimestamp: "2021-07-01T20:28:01Z"


### PR DESCRIPTION


This is a request to approve an autopilot action. The request was triggered based on an AutopilotRule __volume-resize__ defined in your cluster.


## What actions will be taken

### Action: resize

- __Params__: map[maxsize:400Gi scalepercentage:100]

#### ExpectedResult

PVC will resize from 10Gi to 20Gi
 
#### What objects will get affected

- PersistentVolumeClaim pg1/pgbench-data (pvc-76197b64-d738-43de-908b-2cc4d18dd638)
  - Object Owner(s):
    - ReplicaSet pgbench-564dfb97      

## How do I approve

Once you review the above,

- To approve, simply approve and merge this PR
- To declined, close the PR

Autopilot will be watching for the merged specs in the cluster and will proceed with the action if approved and declined the action if not.
